### PR TITLE
Downgrade deps to minimum required versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: "gomod"
-    directory: "/"
+    directory: "/.github/latest-deps"
     schedule:
       interval: "daily"
   - package-ecosystem: "docker"

--- a/.github/latest-deps/go.mod
+++ b/.github/latest-deps/go.mod
@@ -1,0 +1,11 @@
+module github.com/maratori/errors
+
+go 1.22
+
+require github.com/stretchr/testify v1.9.0
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/.github/latest-deps/go.sum
+++ b/.github/latest-deps/go.sum
@@ -1,12 +1,10 @@
-github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
-github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/.github/latest-deps/imports.go
+++ b/.github/latest-deps/imports.go
@@ -1,0 +1,5 @@
+package imports
+
+import (
+	_ "github.com/stretchr/testify/require"
+)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,16 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
-  test19:
+  test-latest-deps:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.22.3" # update together with dev.dockerfile
+      - run: make test-latest-deps
+
+  test18:
     name: "test go 1.18"
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,11 @@ test-cover: ## run all tests with code coverage
 	go test -race -p 8 -parallel 8 -timeout 1m -coverpkg ./... -coverprofile coverage.out ./...
 .PHONY: test-cover
 
+test-latest-deps: ## run all tests with latest dependencies
+	@echo "+ $@"
+	go test -modfile .github/latest-deps/go.mod -race -p 8 -parallel 8 -timeout 1m ./...
+.PHONY: test
+
 lint: build-docker-dev ## run linter
 	@echo "+ $@"
 	$(RUN_IN_DOCKER) golangci-lint run
@@ -28,6 +33,15 @@ bash: build-docker-dev ## run bash inside container for development
  endif
 .PHONY: bash
 
+IMPORTS = find . -name '*.go' -not -path './.github/*' -exec sed -e '/^import (/,/^)/!d' {} + | sed -e '/\./!d' | grep -v "`head -n 1 go.mod | sed -e 's/module //'`" | sed -E -e 's/\t(.+ )?"/\t_ "/' | sort | uniq | xargs -0 printf 'package imports\n\nimport (\n%s)\n'
+
+tidy: ## keep go.mod and .github/latest-deps tidy
+	@echo "+ $@"
+	go mod tidy
+	$(IMPORTS) > .github/latest-deps/imports.go
+	go mod tidy -modfile=.github/latest-deps/go.mod
+.PHONY: check
+
 check-tidy: ## ensure go.mod is tidy
 	@echo "+ $@"
 	cp go.mod go.check.mod
@@ -35,6 +49,17 @@ check-tidy: ## ensure go.mod is tidy
 	go mod tidy -modfile=go.check.mod
 	diff -u go.mod go.check.mod
 	diff -u go.sum go.check.sum
+	rm go.check.mod go.check.sum
+
+	$(IMPORTS) > .github/latest-deps/imports.check.go
+	diff -u .github/latest-deps/imports.go .github/latest-deps/imports.check.go
+	rm .github/latest-deps/imports.check.go
+
+	cp .github/latest-deps/go.mod go.check.mod
+	cp .github/latest-deps/go.sum go.check.sum
+	go mod tidy -modfile=go.check.mod
+	diff -u .github/latest-deps/go.mod go.check.mod
+	diff -u .github/latest-deps/go.sum go.check.sum
 	rm go.check.mod go.check.sum
 .PHONY: check-tidy
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# errors <br> [![go.mod version][go-img]][go-url] [![CI][ci-img]][ci-url] [![Codecov][codecov-img]][codecov-url] [![Maintainability][codeclimate-img]][codeclimate-url] [![Go Report Card][goreportcard-img]][goreportcard-url] [![License][license-img]][license-url] [![Go Reference][godoc-img]][godoc-url]
+# errors <br> [![go minimal version][go-img]][go-url] [![go tested version][go-latest-img]][go-latest-url] [![CI][ci-img]][ci-url] [![Codecov][codecov-img]][codecov-url] [![Maintainability][codeclimate-img]][codeclimate-url] [![Go Report Card][goreportcard-img]][goreportcard-url] [![License][license-img]][license-url] [![Go Reference][godoc-img]][godoc-url]
 
 Go (1.18+) library to construct errors with fields for structured logging.
 
@@ -47,6 +47,8 @@ You are welcome to create an issue or pull request with improvements and fixes. 
 
 [go-img]: https://img.shields.io/github/go-mod/go-version/maratori/errors
 [go-url]: /go.mod
+[go-latest-img]: https://img.shields.io/github/go-mod/go-version/maratori/errors?filename=.github%2Flatest-deps%2Fgo.mod&label=tested
+[go-latest-url]: /.github/latest-deps/go.mod
 [ci-img]: https://github.com/maratori/errors/actions/workflows/ci.yml/badge.svg
 [ci-url]: https://github.com/maratori/errors/actions/workflows/ci.yml
 [codecov-img]: https://codecov.io/gh/maratori/errors/branch/main/graph/badge.svg?token=LPthtc4wLI

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,11 @@
 module github.com/maratori/errors
 
-go 1.18
+go 1.18 // tested all go versions from 1.18 to 1.22
 
-require github.com/stretchr/testify v1.9.0
+require github.com/stretchr/testify v1.7.0
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )


### PR DESCRIPTION
But still validate on CI that it's compatible with the latest versions
